### PR TITLE
Update external resources protocol

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,7 @@
         <title>CodeDaily Editor</title>
         <meta name="description" content="Post Editor for CodeDaily.VN">
         <meta name="author" content="huydotnet">
-        
-        <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.20/angular.min.js"></script>
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular-sanitize.js"></script>
-        <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
-
-        <script src="js/marked.js"></script>
-        <script src="js/editor.js"></script>
-
+         <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
         <link href='style/font.css' rel='stylesheet'>
         <link href='style/editor.css' rel='stylesheet'>
     </head>
@@ -40,5 +33,10 @@
     		<div id="parsed-content" ng-bind-html="editor.parsed"></div>
     	</div>
     	<button class="icon action fa fa-paper-plane" ng-click="onPublish()"></button>
+    	
+    	<script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.20/angular.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular-sanitize.js"></script>
+        <script src="js/marked.js"></script>
+        <script src="js/editor.js"></script>
     </body>
 </html>


### PR DESCRIPTION
As it stands now, the app is broken on sites running over`https`. It is recommended to always request resources in `https` even if your site is running on `http`